### PR TITLE
Jupyterlab1.0

### DIFF
--- a/minimal-notebook/.s2i/bin/assemble
+++ b/minimal-notebook/.s2i/bin/assemble
@@ -8,32 +8,13 @@ set -eo pipefail
 
 # Ensure we are using the latest pip and wheel packages.
 
-pip install -U pip setuptools wheel
+pip install -U pip setuptools wheel --no-cache-dir
 
-# Install mod_wsgi for use in optional webdav support.
-
-pip install 'mod_wsgi==4.6.5'
-
-# Install supervisord for managing multiple applications.
-
-pip install 'supervisor==4.0.2'
-
-# Install base packages needed for running Jupyter Notebooks. 
-
-pip install -r /tmp/src/requirements.txt
-
-# Activate JupyterHub extension for JupyterLab.
-
-function module_installed() {
-    python -c "import sys, pkgutil; sys.exit(0 if pkgutil.find_loader('$1') else 1)"
-}
-
-if module_installed 'jupyterhub' && module_installed 'jupyterlab'; then
-    jupyter labextension install @jupyterlab/hub-extension
-    npm cache clean --force
-    rm -rf $HOME/.cache/yarn
-    rm -rf $HOME/.node-gyp
-fi
+# Install packages and clean up npm cache
+pip install -r /tmp/src/requirements.txt --no-cache-dir
+npm cache clean --force
+rm -rf $HOME/.cache/yarn
+rm -rf $HOME/.node-gyp
 
 # Copy into place default config files for Jupyter and Apache webdav.
 

--- a/minimal-notebook/.s2i/bin/assemble
+++ b/minimal-notebook/.s2i/bin/assemble
@@ -8,10 +8,10 @@ set -eo pipefail
 
 # Ensure we are using the latest pip and wheel packages.
 
-pip install -U pip setuptools wheel --no-cache-dir
+pip install -U pip setuptools wheel
 
 # Install packages and clean up npm cache
-pip install -r /tmp/src/requirements.txt --no-cache-dir
+pip install -r /tmp/src/requirements.txt
 npm cache clean --force
 rm -rf $HOME/.cache/yarn
 rm -rf $HOME/.node-gyp

--- a/minimal-notebook/requirements.txt
+++ b/minimal-notebook/requirements.txt
@@ -1,13 +1,13 @@
 # Install mod_wsgi for use in optional webdav support.
-mod_wsgi==4.6.7
+mod_wsgi==4.6.*
 
 # Install supervisord for managing multiple applications.
-supervisor==4.0.4
+supervisor==4.0.*
 
 # Install base packages needed for running Jupyter Notebooks.
-jupyterhub==0.9.6;python_version>"2.7"
-jupyterlab==1.1.*;python_version>"2.7"
-notebook
-jupyter_kernel_gateway==2.4.0
-dask<3
-distributed<3
+jupyterhub==0.9.6 #update to 1.0.* together with jupyterhub
+jupyterlab==1.1.*
+notebook==6.0.*
+jupyter_kernel_gateway==2.4.*
+dask==2.3.*
+distributed==2.3.*

--- a/minimal-notebook/requirements.txt
+++ b/minimal-notebook/requirements.txt
@@ -1,6 +1,13 @@
+# Install mod_wsgi for use in optional webdav support.
+mod_wsgi==4.6.7
+
+# Install supervisord for managing multiple applications.
+supervisor==4.0.3
+
+# Install base packages needed for running Jupyter Notebooks.
 notebook==5.7.8
 jupyterhub==0.9.6;python_version>"2.7"
-jupyterlab==0.35.6;python_version>"2.7"
+jupyterlab==1.0.*;python_version>"2.7"
 jupyter_kernel_gateway==2.3.0
 dask==1.2.2
 distributed==1.28.1

--- a/minimal-notebook/requirements.txt
+++ b/minimal-notebook/requirements.txt
@@ -2,13 +2,12 @@
 mod_wsgi==4.6.7
 
 # Install supervisord for managing multiple applications.
-supervisor==4.0.3
+supervisor==4.0.4
 
 # Install base packages needed for running Jupyter Notebooks.
-notebook==5.7.8
 jupyterhub==0.9.6;python_version>"2.7"
 jupyterlab==1.0.*;python_version>"2.7"
+notebook
 jupyter_kernel_gateway==2.3.0
-dask==1.2.2
-distributed==1.28.1
-tornado<6.0.0
+dask<3
+distributed<3

--- a/minimal-notebook/requirements.txt
+++ b/minimal-notebook/requirements.txt
@@ -1,13 +1,13 @@
 # Install mod_wsgi for use in optional webdav support.
-mod_wsgi==4.6.*
+mod_wsgi==4.*
 
 # Install supervisord for managing multiple applications.
-supervisor==4.0.*
+supervisor==4.*
 
 # Install base packages needed for running Jupyter Notebooks.
 jupyterhub==0.9.6 #update to 1.0.* together with jupyterhub
-jupyterlab==1.1.*
-notebook==6.0.*
-jupyter_kernel_gateway==2.4.*
-dask==2.3.*
-distributed==2.3.*
+jupyterlab==1.*
+notebook==6.*
+jupyter_kernel_gateway==2.*
+dask==2.*
+distributed==2.*

--- a/minimal-notebook/requirements.txt
+++ b/minimal-notebook/requirements.txt
@@ -6,7 +6,7 @@ supervisor==4.0.4
 
 # Install base packages needed for running Jupyter Notebooks.
 jupyterhub==0.9.6;python_version>"2.7"
-jupyterlab==1.0.*;python_version>"2.7"
+jupyterlab==1.1.*;python_version>"2.7"
 notebook
 jupyter_kernel_gateway==2.4.0
 dask<3

--- a/minimal-notebook/requirements.txt
+++ b/minimal-notebook/requirements.txt
@@ -8,6 +8,6 @@ supervisor==4.0.4
 jupyterhub==0.9.6;python_version>"2.7"
 jupyterlab==1.0.*;python_version>"2.7"
 notebook
-jupyter_kernel_gateway==2.3.0
+jupyter_kernel_gateway==2.4.0
 dask<3
 distributed<3

--- a/scipy-notebook/.s2i/bin/assemble
+++ b/scipy-notebook/.s2i/bin/assemble
@@ -14,8 +14,8 @@ jupyter nbextension enable --py widgetsnbextension --sys-prefix
 
 # Also activate ipywidgets/bokeh extension for JupyterLab.
 
-jupyter labextension install @jupyter-widgets/jupyterlab-manager@^0.38.1
-jupyter labextension install jupyterlab_bokeh@0.6.3
+jupyter labextension install @jupyter-widgets/jupyterlab-manager
+jupyter labextension install jupyterlab_bokeh
 
 # Install facets which does not have a pip package.
 

--- a/scipy-notebook/.s2i/bin/assemble
+++ b/scipy-notebook/.s2i/bin/assemble
@@ -14,8 +14,8 @@ jupyter nbextension enable --py widgetsnbextension --sys-prefix
 
 # Also activate ipywidgets/bokeh extension for JupyterLab.
 
-jupyter labextension install @jupyter-widgets/jupyterlab-manager
-jupyter labextension install jupyterlab_bokeh
+jupyter labextension install @jupyter-widgets/jupyterlab-manager@1.0.*
+jupyter labextension install jupyterlab_bokeh@1.0.*
 
 # Install facets which does not have a pip package.
 

--- a/tensorflow-notebook/.s2i/bin/assemble
+++ b/tensorflow-notebook/.s2i/bin/assemble
@@ -14,8 +14,8 @@ jupyter nbextension enable --py widgetsnbextension --sys-prefix
 
 # Also activate ipywidgets/bokeh extension for JupyterLab.
 
-jupyter labextension install @jupyter-widgets/jupyterlab-manager@^0.38.1
-jupyter labextension install jupyterlab_bokeh@0.6.3
+jupyter labextension install @jupyter-widgets/jupyterlab-manager
+jupyter labextension install jupyterlab_bokeh
 
 # Install facets which does not have a pip package.
 

--- a/tensorflow-notebook/.s2i/bin/assemble
+++ b/tensorflow-notebook/.s2i/bin/assemble
@@ -14,8 +14,8 @@ jupyter nbextension enable --py widgetsnbextension --sys-prefix
 
 # Also activate ipywidgets/bokeh extension for JupyterLab.
 
-jupyter labextension install @jupyter-widgets/jupyterlab-manager
-jupyter labextension install jupyterlab_bokeh
+jupyter labextension install @jupyter-widgets/jupyterlab-manager@1.0.*
+jupyter labextension install jupyterlab_bokeh@1.0.*
 
 # Install facets which does not have a pip package.
 


### PR DESCRIPTION
Update to jupyterlab 1.0.x
JupyterLab now has a File > Logout menu entry when running with JupyterHub.

https://github.com/jupyterlab/jupyterlab/blob/master/docs/source/getting_started/changelog.rst#jupyterhub-integration says "We now include the JupyterHub extension in core JupyterLab, so you no longer need to install @jupyterlab/hub-extension. (#6451, #6428) "

superseedes #12 @GrahamDumpleton 